### PR TITLE
get_field_by_name depreciation fix

### DIFF
--- a/report_builder/mixins.py
+++ b/report_builder/mixins.py
@@ -220,7 +220,13 @@ class DataExportMixin(object):
                     path += '__'  # Legacy format to append a __ here.
 
                 new_model = get_model_from_path_string(model_class, path)
-                model_field = new_model._meta.get_field_by_name(field)[0]
+                try:
+                    model_field = new_model._meta.get_field_by_name(field)[0]
+                except:
+                    try:
+                        model_field = new_model._meta.get_field(field)
+                    except:
+                        model_field = None
                 choices = model_field.choices
                 new_display_fields.append(DisplayField(
                     path, '', field, '', '', None, None, choices, ''

--- a/report_builder/models.py
+++ b/report_builder/models.py
@@ -557,7 +557,10 @@ class DisplayField(AbstractField):
         try:
             model_field = model._meta.get_field_by_name(field_name)[0]
         except:
-            model_field = None
+            try:
+                model_field = model._meta.get_field(field_name)
+            except:
+                model_field = None
         if model_field and model_field.choices:
             return ((model_field.get_prep_value(key), val) for key, val in model_field.choices)
 
@@ -659,7 +662,10 @@ class FilterField(AbstractField):
         try:
             model_field = model._meta.get_field_by_name(field_name)[0]
         except:
-            model_field = None
+            try:
+                model_field = model._meta.get_field(field_name)
+            except:
+                model_field = None
         if model_field and model_field.choices:
             return model_field.choices
 

--- a/report_builder/views.py
+++ b/report_builder/views.py
@@ -34,8 +34,14 @@ def fieldset_string_to_field(fieldset_dict, model):
     i = 0
     for dict_field in fieldset_dict['fields']:
         if isinstance(dict_field, string_types):
-            fieldset_dict['fields'][i] = model._meta.get_field_by_name(
-                dict_field)[0]
+            try:
+                fieldset_dict['fields'][i] = model._meta.get_field_by_name(
+                    dict_field)[0]
+            except:
+                try:
+                    fieldset_dict['fields'][i] = model._meta.get_field(dict_field)
+                except:
+                    fieldset_dict['fields'][i] = None
         elif isinstance(dict_field, list) or isinstance(dict_field, tuple):
             dict_field[1]['recursive'] = True
             fieldset_string_to_field(dict_field[1], model)


### PR DESCRIPTION
django.db.models.options.Options.get_field_by_name() (Model._meta.get_field_by_name()) is deprecated in Django 1.10.

It denies field choices render.